### PR TITLE
Support for renaming files within file copy operation

### DIFF
--- a/src/main/java/sp/sd/fileoperations/dsl/FileOperationsJobDslContext.java
+++ b/src/main/java/sp/sd/fileoperations/dsl/FileOperationsJobDslContext.java
@@ -29,8 +29,20 @@ public class FileOperationsJobDslContext implements Context {
         fileOperations.add(fileCreateOperation);
     }
 
-    public void fileCopyOperation(String includes, String excludes, String targetLocation, boolean flattenFiles) {
-        FileCopyOperation fileCopyOperation = new FileCopyOperation(includes, excludes, targetLocation, flattenFiles);
+    public void fileCopyOperation(String includes,
+                                  String excludes,
+                                  String targetLocation,
+                                  boolean flattenFiles,
+                                  boolean renameFiles,
+                                  String sourceCaptureExpression,
+                                  String targetNameExpression) {
+        FileCopyOperation fileCopyOperation = new FileCopyOperation(includes,
+                                                                    excludes,
+                                                                    targetLocation,
+                                                                    flattenFiles,
+                                                                    renameFiles,
+                                                                    sourceCaptureExpression,
+                                                                    targetNameExpression);
         fileOperations.add(fileCopyOperation);
     }
 

--- a/src/main/resources/sp/sd/fileoperations/FileCopyOperation/config.jelly
+++ b/src/main/resources/sp/sd/fileoperations/FileCopyOperation/config.jelly
@@ -9,14 +9,18 @@
     <f:entry title="Target Location" field="targetLocation">
         <f:textbox field="targetLocation" />
     </f:entry>
-    <f:optionalBlock title="Flatten" field="flattenFiles">
-        <f:optionalBlock title="Rename Files" field="renameFiles">
-            <f:entry title="Source Capture Expression" field="sourceCaptureExpression">
-                <f:textbox field="sourceCaptureExpression" />
-            </f:entry>
-            <f:entry title="Target Name Expression" field="targetNameExpression">
-                <f:textbox field="targetNameExpression" />
-            </f:entry>
-        </f:optionalBlock>
-    </f:optionalBlock>
+    <f:entry title="Flatten" field="flattenFiles">
+        <f:checkbox field="flattenFiles" />
+    </f:entry>
+    <f:advanced>
+        <f:entry title="Rename Files" field="renameFiles">
+            <f:checkbox field="renameFiles" />
+        </f:entry>
+        <f:entry title="Source Capture Expression" field="sourceCaptureExpression">
+            <f:textbox field="sourceCaptureExpression" />
+        </f:entry>
+        <f:entry title="Target Name Expression" field="targetNameExpression">
+            <f:textbox field="targetNameExpression" />
+        </f:entry>
+    </f:advanced>
 </j:jelly>

--- a/src/main/resources/sp/sd/fileoperations/FileCopyOperation/config.jelly
+++ b/src/main/resources/sp/sd/fileoperations/FileCopyOperation/config.jelly
@@ -9,7 +9,14 @@
     <f:entry title="Target Location" field="targetLocation">
         <f:textbox field="targetLocation" />
     </f:entry>
-    <f:entry title="Flatten" field="flattenFiles">
-        <f:checkbox field="flattenFiles" />
-    </f:entry>
+    <f:optionalBlock title="Flatten" field="flattenFiles">
+        <f:optionalBlock title="Rename Files" field="renameFiles">
+            <f:entry title="Source Capture Expression" field="sourceCaptureExpression">
+                <f:textbox field="sourceCaptureExpression" />
+            </f:entry>
+            <f:entry title="Target Name Expression" field="targetNameExpression">
+                <f:textbox field="targetNameExpression" />
+            </f:entry>
+        </f:optionalBlock>
+    </f:optionalBlock>
 </j:jelly>

--- a/src/main/resources/sp/sd/fileoperations/FileCopyOperation/help-flattenFiles.html
+++ b/src/main/resources/sp/sd/fileoperations/FileCopyOperation/help-flattenFiles.html
@@ -1,0 +1,4 @@
+<div>
+    If selected, files are copied directly to the target location without preserving
+    source file sub-directory structure.
+</div>

--- a/src/main/resources/sp/sd/fileoperations/FileCopyOperation/help-renameFiles.html
+++ b/src/main/resources/sp/sd/fileoperations/FileCopyOperation/help-renameFiles.html
@@ -1,0 +1,6 @@
+<div>
+    By default, the file name of the source file is preserved. When flattening
+    files, this can cause problems if files of the same name exist in multiple
+    source sub-directories. Selecting this option allows the output file name 
+    to be manipulated to avoid file name clashes.
+</div>

--- a/src/main/resources/sp/sd/fileoperations/FileCopyOperation/help-sourceCaptureExpression.html
+++ b/src/main/resources/sp/sd/fileoperations/FileCopyOperation/help-sourceCaptureExpression.html
@@ -1,0 +1,6 @@
+<div>
+    Java-style regular expression that is run against the full path of each
+    matching source file. This should be used to capture parts of the path that
+    will be used in the target name expression to make each file name unique
+    across all subdirectories.
+</div>

--- a/src/main/resources/sp/sd/fileoperations/FileCopyOperation/help-targetNameExpression.html
+++ b/src/main/resources/sp/sd/fileoperations/FileCopyOperation/help-targetNameExpression.html
@@ -1,0 +1,4 @@
+<div>
+    An expression that provides the desired target file name. This can reference
+    variables captured in the source capture expression by using $1, $2 etc.
+</div>

--- a/src/test/java/sp/sd/fileoperations/FileCopyOperationTest.java
+++ b/src/test/java/sp/sd/fileoperations/FileCopyOperationTest.java
@@ -28,6 +28,9 @@ public class FileCopyOperationTest {
         assertEquals("**/*.xml", fco.getExcludes());
         assertEquals("target", fco.getTargetLocation());
         assertEquals(true, fco.getFlattenFiles());
+        assertEquals(false, fco.getRenameFiles());
+        assertEquals(null, fco.getSourceCaptureExpression());
+        assertEquals(null, fco.getTargetNameExpression());
     }
 
     @Test
@@ -74,13 +77,19 @@ public class FileCopyOperationTest {
         fop.add(new FileCreateOperation("test-results-xml/pod-0/classB/TestB.xml", ""));
         fop.add(new FileCreateOperation("test-results-xml/pod-1/classB/TestB.xml", ""));
         fop.add(new FileCreateOperation("test-results-xml/pod-1/classC/TestC.xml", ""));
-        fop.add(new FileCopyOperation("test-results-xml/**/*.xml",
-                                      "",
-                                      "test-results",
-                                      true,
-                                      true,
-                                      ".*/test-results-xml/.*-([\\d]+)/.*/([^/]+)$",
-                                      "$1-$2"));
+
+        // Required to handle test being run on either Windows or Unix systems
+        String dirSep = "(?:\\\\|/)";
+
+        fop.add(new FileCopyOperation(
+                "test-results-xml/**/*.xml",
+                "",
+                "test-results",
+                true,
+                true,
+                ".*" + dirSep + "test-results-xml" + dirSep + ".*-([\\d]+)" +
+                        dirSep + ".*" + dirSep + "([^" + dirSep + "]+)$",
+                "$1-$2"));
         p1.getBuildersList().add(new FileOperationsBuilder(fop));
         FreeStyleBuild build = p1.scheduleBuild2(0).get();
         assertEquals(Result.SUCCESS, build.getResult());

--- a/src/test/java/sp/sd/fileoperations/FileCopyOperationTest.java
+++ b/src/test/java/sp/sd/fileoperations/FileCopyOperationTest.java
@@ -1,11 +1,20 @@
 package sp.sd.fileoperations;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.WithoutJenkins;
+
+import hudson.FilePath;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
 
 public class FileCopyOperationTest {
     @Rule
@@ -14,10 +23,70 @@ public class FileCopyOperationTest {
     @Test
     @WithoutJenkins
     public void testDefaults() {
-        FileCopyOperation fco = new FileCopyOperation("**/*.config", "**/*.xml", "target", true);
+        FileCopyOperation fco = new FileCopyOperation("**/*.config", "**/*.xml", "target", true, false, null, null);
         assertEquals("**/*.config", fco.getIncludes());
         assertEquals("**/*.xml", fco.getExcludes());
         assertEquals("target", fco.getTargetLocation());
         assertEquals(true, fco.getFlattenFiles());
+    }
+
+    @Test
+    public void testRunFileOperationWithFileOperationBuildStepNoFlatten() throws Exception {
+        FreeStyleProject p1 = jenkins.createFreeStyleProject("build1");
+        List<FileOperation> fop = new ArrayList<>();
+        fop.add(new FileCreateOperation("test-results-xml/pod-0/classA/TestA.xml", ""));
+        fop.add(new FileCreateOperation("test-results-xml/pod-0/classB/TestB.xml", ""));
+        fop.add(new FileCreateOperation("test-results-xml/pod-1/classB/TestB.xml", ""));
+        fop.add(new FileCreateOperation("test-results-xml/pod-1/classC/TestC.xml", ""));
+        fop.add(new FileCopyOperation("test-results-xml/**/*.xml", "", "test-results", false, false, null, null));
+        p1.getBuildersList().add(new FileOperationsBuilder(fop));
+        FreeStyleBuild build = p1.scheduleBuild2(0).get();
+        assertEquals(Result.SUCCESS, build.getResult());
+        assertTrue(build.getWorkspace().child("test-results/test-results-xml/pod-0/classA/TestA.xml").exists());
+        assertTrue(build.getWorkspace().child("test-results/test-results-xml/pod-0/classB/TestB.xml").exists());
+        assertTrue(build.getWorkspace().child("test-results/test-results-xml/pod-1/classB/TestB.xml").exists());
+        assertTrue(build.getWorkspace().child("test-results/test-results-xml/pod-1/classC/TestC.xml").exists());
+    }
+
+    
+    @Test
+    public void testRunFileOperationWithFileOperationBuildStepWithFlatten() throws Exception {
+        FreeStyleProject p1 = jenkins.createFreeStyleProject("build1");
+        List<FileOperation> fop = new ArrayList<>();
+        fop.add(new FileCreateOperation("test-results-xml/pod-0/classA/TestA.xml", ""));
+        fop.add(new FileCreateOperation("test-results-xml/pod-0/classB/TestB.xml", ""));
+        fop.add(new FileCreateOperation("test-results-xml/pod-1/classB/TestB.xml", ""));
+        fop.add(new FileCreateOperation("test-results-xml/pod-1/classC/TestC.xml", ""));
+        fop.add(new FileCopyOperation("test-results-xml/**/*.xml", "", "test-results", true, false, null, null));
+        p1.getBuildersList().add(new FileOperationsBuilder(fop));
+        FreeStyleBuild build = p1.scheduleBuild2(0).get();
+        assertEquals(Result.SUCCESS, build.getResult());
+        assertTrue(build.getWorkspace().child("test-results/TestA.xml").exists());
+        assertTrue(build.getWorkspace().child("test-results/TestB.xml").exists());
+        assertTrue(build.getWorkspace().child("test-results/TestC.xml").exists());
+    }
+
+    @Test
+    public void testRunFileOperationWithFileOperationBuildStepWithFlattenAndRename() throws Exception {
+        FreeStyleProject p1 = jenkins.createFreeStyleProject("build1");
+        List<FileOperation> fop = new ArrayList<>();
+        fop.add(new FileCreateOperation("test-results-xml/pod-0/classA/TestA.xml", ""));
+        fop.add(new FileCreateOperation("test-results-xml/pod-0/classB/TestB.xml", ""));
+        fop.add(new FileCreateOperation("test-results-xml/pod-1/classB/TestB.xml", ""));
+        fop.add(new FileCreateOperation("test-results-xml/pod-1/classC/TestC.xml", ""));
+        fop.add(new FileCopyOperation("test-results-xml/**/*.xml",
+                                      "",
+                                      "test-results",
+                                      true,
+                                      true,
+                                      ".*/test-results-xml/.*-([\\d]+)/.*/([^/]+)$",
+                                      "$1-$2"));
+        p1.getBuildersList().add(new FileOperationsBuilder(fop));
+        FreeStyleBuild build = p1.scheduleBuild2(0).get();
+        assertEquals(Result.SUCCESS, build.getResult());
+        assertTrue(build.getWorkspace().child("test-results/0-TestA.xml").exists());
+        assertTrue(build.getWorkspace().child("test-results/0-TestB.xml").exists());
+        assertTrue(build.getWorkspace().child("test-results/1-TestB.xml").exists());
+        assertTrue(build.getWorkspace().child("test-results/1-TestC.xml").exists());
     }
 }


### PR DESCRIPTION
Currently, when the flatten option is selected during a file copy operation, files that share the same name within different sub-directories are not handled correctly, with only one of the files ending up in the target directory.

This change implements a regex based file renaming action as part of the file copy, which allows parts of the source file path to be captured and used in the output file name.