### PR TITLE
ADD support for custom output folder in FileZipOperation

### DIFF
--- a/src/main/java/sp/sd/fileoperations/FileZipOperation.java
+++ b/src/main/java/sp/sd/fileoperations/FileZipOperation.java
@@ -17,10 +17,12 @@ import java.io.Serializable;
 public class FileZipOperation extends FileOperation implements Serializable {
 
     private final String folderPath;
+    private final String outputFolderPath;
 
     @DataBoundConstructor
-    public FileZipOperation(String folderPath) {
+    public FileZipOperation(String folderPath, String outputFolderPath) {
         this.folderPath = folderPath;
+        this.outputFolderPath = outputFolderPath;
     }
 
     public String getFolderPath() {
@@ -34,7 +36,7 @@ public class FileZipOperation extends FileOperation implements Serializable {
             EnvVars envVars = run.getEnvironment(listener);
             try {
                 FilePath ws = new FilePath(buildWorkspace, ".");
-                result = ws.act(new TargetFileCallable(listener, envVars.expand(folderPath), envVars));
+                result = ws.act(new TargetFileCallable(listener, envVars.expand(folderPath), envVars.expand(outputFolderPath), envVars));
             } catch (Exception e) {
                 listener.fatalError(e.getMessage());
                 return false;
@@ -50,10 +52,12 @@ public class FileZipOperation extends FileOperation implements Serializable {
         private final TaskListener listener;
         private final EnvVars environment;
         private final String resolvedFolderPath;
+        private final String outputFolderPath;
 
-        public TargetFileCallable(TaskListener Listener, String ResolvedFolderPath, EnvVars environment) {
+        public TargetFileCallable(TaskListener Listener, String ResolvedFolderPath, String outputFolderPath, EnvVars environment) {
             this.listener = Listener;
             this.resolvedFolderPath = ResolvedFolderPath;
+            this.outputFolderPath = outputFolderPath;
             this.environment = environment;
         }
 
@@ -62,9 +66,10 @@ public class FileZipOperation extends FileOperation implements Serializable {
             boolean result;
             try {
                 FilePath fpWS = new FilePath(ws);
+                FilePath fpWSOutput = new FilePath(fpWS, outputFolderPath);
                 FilePath fpTL = new FilePath(fpWS, resolvedFolderPath);
                 listener.getLogger().println("Creating Zip file of " + fpTL.getRemote());
-                fpTL.zip(new FilePath(fpWS, fpTL.getName() + ".zip"));
+                fpTL.zip(new FilePath(fpWSOutput, fpTL.getName() + ".zip"));
                 result = true;
             } catch (RuntimeException e) {
                 listener.fatalError(e.getMessage());

--- a/src/main/java/sp/sd/fileoperations/dsl/FileOperationsJobDslContext.java
+++ b/src/main/java/sp/sd/fileoperations/dsl/FileOperationsJobDslContext.java
@@ -81,8 +81,8 @@ public class FileOperationsJobDslContext implements Context {
         fileOperations.add(fileUnZipOperation);
     }
 
-    public void fileZipOperation(String folderPath) {
-        FileZipOperation fileZipOperation = new FileZipOperation(folderPath);
+    public void fileZipOperation(String folderPath, String outputFolderPath) {
+        FileZipOperation fileZipOperation = new FileZipOperation(folderPath, outputFolderPath);
         fileOperations.add(fileZipOperation);
     }
 

--- a/src/main/resources/sp/sd/fileoperations/FileZipOperation/config.jelly
+++ b/src/main/resources/sp/sd/fileoperations/FileZipOperation/config.jelly
@@ -3,4 +3,7 @@
     <f:entry title="Folder Path" field="folderPath">
         <f:textbox field="folderPath" />
     </f:entry>
+    <f:entry title="Output Folder Path" field="outputFolderPath">
+        <f:textbox field="outputFolderPath" />
+    </f:entry>
 </j:jelly>


### PR DESCRIPTION
We wanted to use this plugin for zipping our build files before uploading them to our server. Doing so, we've realized that you can not specify an output directory and instead the zip operation always just throws the zip file into the root workspace directory. 

It would be great if you could specify the output directory instead. 