### PR TITLE
Fix issues introduced by custom output folder in FileZipOperation

### DIFF
--- a/src/main/java/sp/sd/fileoperations/FileZipOperation.java
+++ b/src/main/java/sp/sd/fileoperations/FileZipOperation.java
@@ -29,6 +29,10 @@ public class FileZipOperation extends FileOperation implements Serializable {
         return folderPath;
     }
 
+    public String getOutputFolderPath() {
+        return outputFolderPath;
+    }
+
     public boolean runOperation(Run<?, ?> run, FilePath buildWorkspace, Launcher launcher, TaskListener listener) {
         boolean result = false;
         try {
@@ -66,9 +70,11 @@ public class FileZipOperation extends FileOperation implements Serializable {
             boolean result;
             try {
                 FilePath fpWS = new FilePath(ws);
-                FilePath fpWSOutput = new FilePath(fpWS, outputFolderPath);
+                FilePath fpWSOutput = 
+                    new FilePath(fpWS, (outputFolderPath != null ? outputFolderPath : ""));
                 FilePath fpTL = new FilePath(fpWS, resolvedFolderPath);
-                listener.getLogger().println("Creating Zip file of " + fpTL.getRemote());
+                listener.getLogger().println(
+                    "Creating Zip file of " + fpTL.getRemote() + " in " + fpWSOutput);
                 fpTL.zip(new FilePath(fpWSOutput, fpTL.getName() + ".zip"));
                 result = true;
             } catch (RuntimeException e) {

--- a/src/main/resources/sp/sd/fileoperations/FileZipOperation/help-folderPath.html
+++ b/src/main/resources/sp/sd/fileoperations/FileZipOperation/help-folderPath.html
@@ -1,3 +1,3 @@
 <div>
-    Path of the folder to create zip file in workspace.
+    Path of the file or folder to create a zip file for, relative to the workspace directory.
 </div>

--- a/src/main/resources/sp/sd/fileoperations/FileZipOperation/help-outputFolderPath.html
+++ b/src/main/resources/sp/sd/fileoperations/FileZipOperation/help-outputFolderPath.html
@@ -1,0 +1,4 @@
+<div>
+    Path to a target directory for the zip file, relative to the workspace directory.
+    Defaults to workspace directory if not defined.
+</div>

--- a/src/test/java/sp/sd/fileoperations/FileZipOperationTest.java
+++ b/src/test/java/sp/sd/fileoperations/FileZipOperationTest.java
@@ -1,0 +1,108 @@
+package sp.sd.fileoperations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.WithoutJenkins;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+
+public class FileZipOperationTest {
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    @Test
+    @WithoutJenkins
+    public void testDefaults() {
+        FileZipOperation fzo = new FileZipOperation("source", null);
+        assertEquals("source", fzo.getFolderPath());
+        assertNull(fzo.getOutputFolderPath());
+    }
+
+    @Test
+    public void testRunFileOperationZipDirectoryToDefaultOutput() throws Exception {
+        FreeStyleProject p1 = jenkins.createFreeStyleProject("build1");
+        List<FileOperation> fop = new ArrayList<>();
+        fop.add(new FileCreateOperation("source-directory/nested-folder1/TestFile1-1", ""));
+        fop.add(new FileCreateOperation("source-directory/nested-folder2/TestFile2-1", ""));
+        fop.add(new FileCreateOperation("source-directory/nested-folder2/TestFile2-2", ""));
+        fop.add(new FileZipOperation("source-directory", null));
+        fop.add(new FileUnZipOperation("source-directory.zip", "unzipped-directory"));
+        p1.getBuildersList().add(new FileOperationsBuilder(fop));
+
+        FreeStyleBuild build = p1.scheduleBuild2(0).get();
+
+        assertEquals(Result.SUCCESS, build.getResult());
+        assertTrue(build.getWorkspace().child("unzipped-directory").exists());
+        assertTrue(build.getWorkspace().child("unzipped-directory/source-directory/nested-folder1/TestFile1-1").exists());
+        assertTrue(build.getWorkspace().child("unzipped-directory/source-directory/nested-folder2/TestFile2-1").exists());
+        assertTrue(build.getWorkspace().child("unzipped-directory/source-directory/nested-folder2/TestFile2-2").exists());
+    }
+
+    @Test
+    public void testRunFileOperationZipFileToDefaultOutput() throws Exception {
+        FreeStyleProject p1 = jenkins.createFreeStyleProject("build1");
+        List<FileOperation> fop = new ArrayList<>();
+        fop.add(new FileCreateOperation("source-directory/nested-folder1/TestFile1-1", ""));
+        fop.add(new FileZipOperation("source-directory/nested-folder1/TestFile1-1", null));
+        fop.add(new FileUnZipOperation("TestFile1-1.zip", "unzipped-directory"));
+        p1.getBuildersList().add(new FileOperationsBuilder(fop));
+
+        FreeStyleBuild build = p1.scheduleBuild2(0).get();
+
+        assertEquals(Result.SUCCESS, build.getResult());
+        assertTrue(build.getWorkspace().child("unzipped-directory").exists());
+        assertTrue(build.getWorkspace().child("unzipped-directory/TestFile1-1").exists());
+    }
+
+    @Test
+    public void testRunFileOperationZipDirectoryToCustomOutput() throws Exception {
+        FreeStyleProject p1 = jenkins.createFreeStyleProject("build1");
+        List<FileOperation> fop = new ArrayList<>();
+        fop.add(new FileCreateOperation("source-directory/nested-folder1/TestFile1-1", ""));
+        fop.add(new FileCreateOperation("source-directory/nested-folder2/TestFile2-1", ""));
+        fop.add(new FileCreateOperation("source-directory/nested-folder2/TestFile2-2", ""));
+        fop.add(new FileZipOperation("source-directory", "output-directory/nested-output-folder1"));
+        fop.add(new FileUnZipOperation(
+            "output-directory/nested-output-folder1/source-directory.zip",
+            "unzipped-directory"));
+        p1.getBuildersList().add(new FileOperationsBuilder(fop));
+
+        FreeStyleBuild build = p1.scheduleBuild2(0).get();
+
+        assertEquals(Result.SUCCESS, build.getResult());
+        assertTrue(build.getWorkspace().child("unzipped-directory").exists());
+        assertTrue(build.getWorkspace().child("unzipped-directory/source-directory/nested-folder1/TestFile1-1").exists());
+        assertTrue(build.getWorkspace().child("unzipped-directory/source-directory/nested-folder2/TestFile2-1").exists());
+        assertTrue(build.getWorkspace().child("unzipped-directory/source-directory/nested-folder2/TestFile2-2").exists());
+    }
+
+    @Test
+    public void testRunFileOperationZipFileToCustomOutput() throws Exception {
+        FreeStyleProject p1 = jenkins.createFreeStyleProject("build1");
+        List<FileOperation> fop = new ArrayList<>();
+        fop.add(new FileCreateOperation("source-directory/nested-folder1/TestFile1-1", ""));
+        fop.add(new FileZipOperation(
+            "source-directory/nested-folder1/TestFile1-1",
+            "output-directory/nested-output-folder1"));
+        fop.add(new FileUnZipOperation(
+            "output-directory/nested-output-folder1/TestFile1-1.zip",
+            "unzipped-directory"));
+        p1.getBuildersList().add(new FileOperationsBuilder(fop));
+
+        FreeStyleBuild build = p1.scheduleBuild2(0).get();
+
+        assertEquals(Result.SUCCESS, build.getResult());
+        assertTrue(build.getWorkspace().child("unzipped-directory").exists());
+        assertTrue(build.getWorkspace().child("unzipped-directory/TestFile1-1").exists());
+    }
+}


### PR DESCRIPTION
Fix the following issues introduced by https://github.com/jenkinsci/file-operations-plugin/pull/12:

- Existing behaviour was broken when the new outputFolderPath was not specified. This has been fixed and now outputs to the workspace directory by default (as in earlier versions)
- Previously specified outputFolderPath values would not appear when modifying a project configuration, due to no getter being implemented for the new variable.
- Pipeline snippet generator was broken for the same reason.

Also added some basic unit tests for the file zip operation and tweaked / extended the help text.