### PR TITLE
Remove unnecessary version numbers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,12 +59,10 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>apache-httpcomponents-client-4-api</artifactId>
-            <version>4.5.14-150.v7a_b_9d17134a_5</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jackson2-api</artifactId>
-            <version>2.15.0-334.v317a_165f9b_7c</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
The point of using `jenkinsci/bom` is to avoid having to manually specify such version numbers, instead relying on the BOM to provide a well-defined (and tested) set of version numbers of compatible plugins.