### PR TITLE
Allow copy and delete of ant default exclude files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@
             <version>1.87</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+            <version>1.4.20</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/sp/sd/fileoperations/FileDeleteOperation.java
+++ b/src/main/java/sp/sd/fileoperations/FileDeleteOperation.java
@@ -9,6 +9,7 @@ import hudson.model.TaskListener;
 
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 import java.io.File;
 
@@ -21,11 +22,13 @@ import java.io.Serializable;
 public class FileDeleteOperation extends FileOperation implements Serializable {
     private final String includes;
     private final String excludes;
+    private Boolean useDefaultExcludes;
 
     @DataBoundConstructor
     public FileDeleteOperation(String includes, String excludes) {
         this.includes = includes;
         this.excludes = excludes;
+        this.useDefaultExcludes = true;
     }
 
     public String getIncludes() {
@@ -36,6 +39,10 @@ public class FileDeleteOperation extends FileOperation implements Serializable {
         return excludes;
     }
 
+    public boolean getUseDefaultExcludes() {
+        return useDefaultExcludes;
+    }
+
     public boolean runOperation(Run<?, ?> run, FilePath buildWorkspace, Launcher launcher, TaskListener listener) {
         boolean result = false;
         try {
@@ -43,7 +50,7 @@ public class FileDeleteOperation extends FileOperation implements Serializable {
             EnvVars envVars = run.getEnvironment(listener);
             try {
                 FilePath ws = new FilePath(buildWorkspace, ".");
-                result = ws.act(new TargetFileCallable(listener, envVars.expand(includes), envVars.expand(excludes)));
+                result = ws.act(new TargetFileCallable(listener, envVars.expand(includes), envVars.expand(excludes), useDefaultExcludes));
             } catch (Exception e) {
                 listener.fatalError(e.getMessage());
                 return false;
@@ -60,11 +67,13 @@ public class FileDeleteOperation extends FileOperation implements Serializable {
         private final TaskListener listener;
         private final String resolvedIncludes;
         private final String resolvedExcludes;
+        private final boolean useDefaultExcludes;
 
-        public TargetFileCallable(TaskListener Listener, String ResolvedIncludes, String ResolvedExcludes) {
+        public TargetFileCallable(TaskListener Listener, String ResolvedIncludes, String ResolvedExcludes, boolean UseDefaultExcludes) {
             this.listener = Listener;
             this.resolvedIncludes = ResolvedIncludes;
             this.resolvedExcludes = ResolvedExcludes;
+            this.useDefaultExcludes = UseDefaultExcludes;
         }
 
         @Override
@@ -72,7 +81,7 @@ public class FileDeleteOperation extends FileOperation implements Serializable {
             boolean result = false;
             try {
                 FilePath fpWS = new FilePath(ws);
-                FilePath[] resolvedFiles = fpWS.list(resolvedIncludes, resolvedExcludes);
+                FilePath[] resolvedFiles = fpWS.list(resolvedIncludes, resolvedExcludes, useDefaultExcludes);
                 if (resolvedFiles.length == 0) {
                     listener.getLogger().println("0 files found for include pattern '" + resolvedIncludes + "' and exclude pattern '" + resolvedExcludes + "'");
                     result = true;
@@ -127,6 +136,17 @@ public class FileDeleteOperation extends FileOperation implements Serializable {
         public String getDisplayName() {
             return "File Delete";
         }
+    }
 
+    @DataBoundSetter
+    public void setUseDefaultExcludes(boolean useDefaultExcludes) {
+        this.useDefaultExcludes = useDefaultExcludes;
+    }
+
+    protected Object readResolve() {
+        if (useDefaultExcludes == null) {
+            useDefaultExcludes = true;
+        }
+        return this;
     }
 }

--- a/src/main/java/sp/sd/fileoperations/dsl/FileOperationsJobDslContext.java
+++ b/src/main/java/sp/sd/fileoperations/dsl/FileOperationsJobDslContext.java
@@ -35,20 +35,44 @@ public class FileOperationsJobDslContext implements Context {
                                   boolean flattenFiles,
                                   boolean renameFiles,
                                   String sourceCaptureExpression,
-                                  String targetNameExpression) {
+                                  String targetNameExpression,
+                                  boolean useDefaultExcludes) {
         FileCopyOperation fileCopyOperation = new FileCopyOperation(includes,
-                                                                    excludes,
-                                                                    targetLocation,
-                                                                    flattenFiles,
-                                                                    renameFiles,
-                                                                    sourceCaptureExpression,
-                                                                    targetNameExpression);
+                excludes,
+                targetLocation,
+                flattenFiles,
+                renameFiles,
+                sourceCaptureExpression,
+                targetNameExpression);
+        fileCopyOperation.setUseDefaultExcludes(useDefaultExcludes);
         fileOperations.add(fileCopyOperation);
     }
 
-    public void fileDeleteOperation(String includes, String excludes) {
+    public void fileCopyOperation(String includes,
+                                  String excludes,
+                                  String targetLocation,
+                                  boolean flattenFiles,
+                                  boolean renameFiles,
+                                  String sourceCaptureExpression,
+                                  String targetNameExpression) {
+        fileCopyOperation(includes,
+                          excludes,
+                          targetLocation,
+                          flattenFiles,
+                          renameFiles,
+                          sourceCaptureExpression,
+                          targetNameExpression,
+                          true);
+    }
+
+    public void fileDeleteOperation(String includes, String excludes, boolean useDefaultExcludes) {
         FileDeleteOperation fileDeleteOperation = new FileDeleteOperation(includes, excludes);
+        fileDeleteOperation.setUseDefaultExcludes(useDefaultExcludes);
         fileOperations.add(fileDeleteOperation);
+    }
+
+    public void fileDeleteOperation(String includes, String excludes) {
+        fileDeleteOperation(includes, excludes, true);
     }
 
     public void fileDownloadOperation(String url, String userName, String password, String targetLocation, String targetFileName, String proxyHost, String proxyPort) {
@@ -66,9 +90,14 @@ public class FileOperationsJobDslContext implements Context {
         fileOperations.add(filePropertiesToJsonOperation);
     }
 
-    public void fileTransformOperation(String includes, String excludes) {
+    public void fileTransformOperation(String includes, String excludes, boolean useDefaultExcludes) {
         FileTransformOperation fileTransformOperation = new FileTransformOperation(includes, excludes);
+        fileTransformOperation.setUseDefaultExcludes(useDefaultExcludes);
         fileOperations.add(fileTransformOperation);
+    }
+
+    public void fileTransformOperation(String includes, String excludes) {
+        fileTransformOperation(includes, excludes, true);
     }
 
     public void fileUnTarOperation(String filePath, String targetLocation, boolean isGZIP) {

--- a/src/test/java/sp/sd/fileoperations/FileDeleteOperationTest.java
+++ b/src/test/java/sp/sd/fileoperations/FileDeleteOperationTest.java
@@ -2,7 +2,10 @@ package sp.sd.fileoperations;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.security.AnyTypePermission;
 import hudson.EnvVars;
 import hudson.model.FreeStyleBuild;
 import hudson.model.Result;
@@ -10,6 +13,7 @@ import hudson.model.FreeStyleProject;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Rule;
@@ -27,39 +31,119 @@ public class FileDeleteOperationTest {
         FileDeleteOperation fdo = new FileDeleteOperation("**/*.txt", "**/*.xml");
         assertEquals("**/*.txt", fdo.getIncludes());
         assertEquals("**/*.xml", fdo.getExcludes());
+        assertEquals(true, fdo.getUseDefaultExcludes());
     }
 
     @Test
     public void testRunFileOperationWithFileOperationBuildStep() throws Exception {
-        FreeStyleProject p1 = jenkins.createFreeStyleProject("build1");
+        // Given
         FileCreateOperation fco = new FileCreateOperation("NewFileName.txt", "This is File Content");
         FileDeleteOperation fdo = new FileDeleteOperation("**/*.txt", "**/*.xml");
         List<FileOperation> fop = new ArrayList<>();
         fop.add(fco);
         fop.add(fdo);
+
+        // When
+        FreeStyleProject p1 = jenkins.createFreeStyleProject("build1");
         p1.getBuildersList().add(new FileOperationsBuilder(fop));
         FreeStyleBuild build = p1.scheduleBuild2(0).get();
+
+        // Then
         assertEquals(Result.SUCCESS, build.getResult());
         assertFalse(build.getWorkspace().child("NewFileName.txt").exists());
     }
 
     @Test
     public void testRunFileOperationWithFileOperationBuildStepWithTokens() throws Exception {
-
+        // Given
         EnvironmentVariablesNodeProperty prop = new EnvironmentVariablesNodeProperty();
         EnvVars envVars = prop.getEnvVars();
         envVars.put("TextFileName", "NewFileName.txt");
         jenkins.jenkins.getGlobalNodeProperties().add(prop);
 
-        FreeStyleProject p1 = jenkins.createFreeStyleProject("build1");
         FileCreateOperation fco = new FileCreateOperation("$TextFileName", "This is File Content");
         FileDeleteOperation fdo = new FileDeleteOperation("**/*.txt", "**/*.xml");
         List<FileOperation> fop = new ArrayList<>();
         fop.add(fco);
         fop.add(fdo);
+
+        // When
+        FreeStyleProject p1 = jenkins.createFreeStyleProject("build1");
         p1.getBuildersList().add(new FileOperationsBuilder(fop));
         FreeStyleBuild build = p1.scheduleBuild2(0).get();
+
+        // Then
         assertEquals(Result.SUCCESS, build.getResult());
         assertFalse(build.getWorkspace().child("NewFileName.txt").exists());
+    }
+
+    @Test
+    public void testRunFileOperationWithFileOperationBuildStepWithDefaultExcludes() throws Exception {
+        // Given
+        FileCreateOperation fco = new FileCreateOperation(".gitignore", "This is File Content");
+        FileDeleteOperation fdo = new FileDeleteOperation(".gitignore", "");
+        List<FileOperation> fop = Arrays.asList(fco, fdo);
+
+        // When
+        FreeStyleProject p1 = jenkins.createFreeStyleProject("build1");
+        p1.getBuildersList().add(new FileOperationsBuilder(fop));
+        FreeStyleBuild build = p1.scheduleBuild2(0).get();
+
+        // Then
+        assertEquals(Result.SUCCESS, build.getResult());
+        assertTrue(build.getWorkspace().child(".gitignore").exists());
+    }
+
+    @Test
+    public void testRunFileOperationWithFileOperationBuildStepWithoutDefaultExcludes() throws Exception {
+        // Given
+        FileCreateOperation fco = new FileCreateOperation(".gitignore", "This is File Content");
+        FileDeleteOperation fdo = new FileDeleteOperation(".gitignore", "");
+        fdo.setUseDefaultExcludes(false);
+        List<FileOperation> fop = Arrays.asList(fco, fdo);
+
+        // When
+        FreeStyleProject p1 = jenkins.createFreeStyleProject("build1");
+        p1.getBuildersList().add(new FileOperationsBuilder(fop));
+        FreeStyleBuild build = p1.scheduleBuild2(0).get();
+
+        // Then
+        assertEquals(Result.SUCCESS, build.getResult());
+        assertFalse(build.getWorkspace().child(".gitignore").exists());
+    }
+
+    @Test
+    @WithoutJenkins
+    public void testSerializeWithXStream() {
+        // Given
+        FileDeleteOperation originalObject = new FileDeleteOperation("include", "exclude");
+        originalObject.setUseDefaultExcludes(false);
+
+        // When
+        XStream xstream = new XStream();
+        xstream.addPermission(AnyTypePermission.ANY);
+        String serializedObjectXml = xstream.toXML(originalObject);
+        FileDeleteOperation deserializedObject = (FileDeleteOperation)xstream.fromXML(serializedObjectXml);
+
+        // Then
+        assertEquals(originalObject.getIncludes(), deserializedObject.getIncludes());
+        assertEquals(originalObject.getExcludes(), deserializedObject.getExcludes());
+        assertEquals(originalObject.getUseDefaultExcludes(), deserializedObject.getUseDefaultExcludes());
+    }
+
+    @Test
+    @WithoutJenkins
+    public void testSerializeWithXStreamBackwardsCompatibility() {
+        // Given
+        String serializedObjectXml = "<FileDeleteOperation><includes>include</includes><excludes>exclude</excludes></FileDeleteOperation>";
+
+        // When
+        XStream xstream = new XStream();
+        xstream.alias("FileDeleteOperation", FileDeleteOperation.class);
+        xstream.addPermission(AnyTypePermission.ANY);
+        FileDeleteOperation deserializedObject = (FileDeleteOperation)xstream.fromXML(serializedObjectXml);
+
+        // Then
+        assertTrue(deserializedObject.getUseDefaultExcludes());
     }
 }

--- a/src/test/java/sp/sd/fileoperations/FileTransformOperationTest.java
+++ b/src/test/java/sp/sd/fileoperations/FileTransformOperationTest.java
@@ -1,13 +1,30 @@
 package sp.sd.fileoperations;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.security.AnyTypePermission;
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.WithoutJenkins;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class FileTransformOperationTest {
+
     @Rule
     public JenkinsRule jenkins = new JenkinsRule();
 
@@ -17,5 +34,121 @@ public class FileTransformOperationTest {
         FileTransformOperation fto = new FileTransformOperation("NewFileName.config", "**/*.xml");
         assertEquals("NewFileName.config", fto.getIncludes());
         assertEquals("**/*.xml", fto.getExcludes());
+        assertEquals(true, fto.getUseDefaultExcludes());
+    }
+
+    static final class FileOperationPutEnvironment extends FileOperation {
+        public final transient JenkinsRule jenkins;
+        public final transient String key;
+        public final transient String value;
+
+        public FileOperationPutEnvironment(JenkinsRule jenkins, String key, String value) {
+            this.jenkins = jenkins;
+            this.key = key;
+            this.value = value;
+        }
+
+        public boolean runOperation(Run<?, ?> run, FilePath buildWorkspace, Launcher launcher, TaskListener listener) {
+            try {
+                EnvironmentVariablesNodeProperty prop = new EnvironmentVariablesNodeProperty();
+                EnvVars envVars = prop.getEnvVars();
+                envVars.put(key, value);
+                jenkins.jenkins.getGlobalNodeProperties().add(prop);
+            } catch (Exception e) {
+                fail("Unexpected exception during environment put.");
+            }
+            return true;
+        }
+    }
+
+    @Test
+    public void testRunFileOperationWithFileOperationBuildStepWithTokens() throws Exception {
+        // Given
+        FileCreateOperation fco = new FileCreateOperation("TestFile.txt", "$Content");
+        FileOperationPutEnvironment fpo = new FileOperationPutEnvironment(jenkins, "Content", "ReplacementContent");
+        FileTransformOperation fto = new FileTransformOperation("TestFile.txt", "");
+        List<FileOperation> fop = Arrays.asList(fco, fpo, fto);
+
+        // When
+        FreeStyleProject p1 = jenkins.createFreeStyleProject("build1");
+        p1.getBuildersList().add(new FileOperationsBuilder(fop));
+        FreeStyleBuild build = p1.scheduleBuild2(0).get();
+
+        // Then
+        assertEquals(Result.SUCCESS, build.getResult());
+        assertEquals("ReplacementContent", build.getWorkspace().child("TestFile.txt").readToString());
+    }
+
+    @Test
+    public void testRunFileOperationWithFileOperationBuildStepWithDefaultExcludes() throws Exception {
+        // Given
+        FileCreateOperation fco = new FileCreateOperation(".gitignore", "$Content");
+        FileOperationPutEnvironment fpo = new FileOperationPutEnvironment(jenkins, "Content", "ReplacementContent");
+        FileTransformOperation fto = new FileTransformOperation(".gitignore", "");
+        List<FileOperation> fop = Arrays.asList(fco, fpo, fto);
+
+        // When
+        FreeStyleProject p1 = jenkins.createFreeStyleProject("build1");
+        p1.getBuildersList().add(new FileOperationsBuilder(fop));
+        FreeStyleBuild build = p1.scheduleBuild2(0).get();
+
+        // Then
+        assertEquals(Result.SUCCESS, build.getResult());
+        assertTrue(build.getWorkspace().child(".gitignore").exists());
+        assertEquals("$Content", build.getWorkspace().child(".gitignore").readToString());
+    }
+
+    @Test
+    public void testRunFileOperationWithFileOperationBuildStepWithoutDefaultExcludes() throws Exception {
+        // Given
+        FileCreateOperation fco = new FileCreateOperation(".gitignore", "$Content");
+        FileOperationPutEnvironment fpo = new FileOperationPutEnvironment(jenkins, "Content", "ReplacementContent");
+        FileTransformOperation fto = new FileTransformOperation(".gitignore", "");
+        fto.setUseDefaultExcludes(false);
+        List<FileOperation> fop = Arrays.asList(fco, fpo, fto);
+
+        // When
+        FreeStyleProject p1 = jenkins.createFreeStyleProject("build1");
+        p1.getBuildersList().add(new FileOperationsBuilder(fop));
+        FreeStyleBuild build = p1.scheduleBuild2(0).get();
+
+        // Then
+        assertEquals(Result.SUCCESS, build.getResult());
+        assertEquals("ReplacementContent", build.getWorkspace().child(".gitignore").readToString());
+    }
+
+    @Test
+    @WithoutJenkins
+    public void testSerializeWithXStream() {
+        // Given
+        FileTransformOperation originalObject = new FileTransformOperation("include", "exclude");
+        originalObject.setUseDefaultExcludes(false);
+
+        // When
+        XStream xstream = new XStream();
+        xstream.addPermission(AnyTypePermission.ANY);
+        String serializedObjectXml = xstream.toXML(originalObject);
+        FileTransformOperation deserializedObject = (FileTransformOperation)xstream.fromXML(serializedObjectXml);
+
+        // Then
+        assertEquals(originalObject.getIncludes(), deserializedObject.getIncludes());
+        assertEquals(originalObject.getExcludes(), deserializedObject.getExcludes());
+        assertEquals(originalObject.getUseDefaultExcludes(), deserializedObject.getUseDefaultExcludes());
+    }
+
+    @Test
+    @WithoutJenkins
+    public void testSerializeWithXStreamBackwardsCompatibility() {
+        // Given
+        String serializedObjectXml = "<FileTransformOperation><includes>include</includes><excludes>exclude</excludes></FileTransformOperation>";
+
+        // When
+        XStream xstream = new XStream();
+        xstream.alias("FileTransformOperation", FileTransformOperation.class);
+        xstream.addPermission(AnyTypePermission.ANY);
+        FileTransformOperation deserializedObject = (FileTransformOperation)xstream.fromXML(serializedObjectXml);
+
+        // Then
+        assertTrue(deserializedObject.getUseDefaultExcludes());
     }
 }


### PR DESCRIPTION
Hi,

I recently had to setup at build machine and noticed that it is not possible to copy or delete .gitignore files.
We are using this plugin for file operations, so it is a bit annoying and I thought I would try a pull request.

Currently, it is not possible to copy or delete files with the following names when using FileCopyOperation and FileDeleteOperation:

CVS
.cvsignore
SCCS
vssver.scc
.svn
.DS_Store
.git
.gitattributes
.gitignore
.gitmodules
.hg
.hgignore
.hgsub
.hgsubstate
.hgtags
.bzr
.bzrignore

Since the glob Ant pattern that FilePath::list and FilePath::copyRecursiveTo uses cannot pick up the files. This change changes to not use the default exclude list, so e.g. it is possible to copy and delete .gitignore files.

The Ant default exclude files are listed here:
https://ant.apache.org/manual/dirtasks.html#defaultexcludes

### Testing done

I have added two automated tests that fail before this change, and pass after the change.

### Submitter checklist
- [ x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
- [x ] Link to relevant issues in GitHub or Jira
- [x ] Link to relevant pull requests, esp. upstream and downstream changes
- [x ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
