### PR TITLE
Add Tests for FileJoinOperation

### DIFF
--- a/src/test/java/sp/sd/fileoperations/FileJoinOperationTest.java
+++ b/src/test/java/sp/sd/fileoperations/FileJoinOperationTest.java
@@ -32,23 +32,18 @@ public class FileJoinOperationTest {
     public void testRunFileJoinOperation() throws Exception {
         FreeStyleProject project = jenkins.createFreeStyleProject("fileJoinTest");
 
-        // Setup source file content
         FilePath sourceFile = new FilePath(jenkins.jenkins.getWorkspaceFor(project), "source.txt");
         sourceFile.write("Source File Content", StandardCharsets.UTF_8.name());
 
-        // Setup target file content
         FilePath targetFile = new FilePath(jenkins.jenkins.getWorkspaceFor(project), "target.txt");
         targetFile.write("Target File Content", StandardCharsets.UTF_8.name());
 
-        // Add FileJoinOperation to project
         FileJoinOperation fileJoinOp = new FileJoinOperation("source.txt", "target.txt");
         project.getBuildersList().add(new FileOperationsBuilder(List.of(fileJoinOp)));
 
-        // Run the build
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         assertEquals(Result.SUCCESS, build.getResult());
 
-        // Verify file join
         String expectedContent = "Target File Content\nSource File Content";
         String actualContent = targetFile.readToString();
         assertEquals(expectedContent, actualContent);
@@ -56,7 +51,6 @@ public class FileJoinOperationTest {
 
     @Test
     public void testRunFileJoinOperationWithTokens() throws Exception {
-        // Setup environment variables
         EnvironmentVariablesNodeProperty prop = new EnvironmentVariablesNodeProperty();
         EnvVars envVars = prop.getEnvVars();
         envVars.put("SOURCE_FILE", "source.txt");
@@ -65,23 +59,18 @@ public class FileJoinOperationTest {
 
         FreeStyleProject project = jenkins.createFreeStyleProject("fileJoinTestWithTokens");
 
-        // Setup source file content
         FilePath sourceFile = new FilePath(jenkins.jenkins.getWorkspaceFor(project), "source.txt");
         sourceFile.write("Source File Content", StandardCharsets.UTF_8.name());
 
-        // Setup target file content
         FilePath targetFile = new FilePath(jenkins.jenkins.getWorkspaceFor(project), "target.txt");
         targetFile.write("Target File Content", StandardCharsets.UTF_8.name());
 
-        // Add FileJoinOperation to project
         FileJoinOperation fileJoinOp = new FileJoinOperation("$SOURCE_FILE", "$TARGET_FILE");
         project.getBuildersList().add(new FileOperationsBuilder(List.of(fileJoinOp)));
 
-        // Run the build
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         assertEquals(Result.SUCCESS, build.getResult());
 
-        // Verify file join
         String expectedContent = "Target File Content\nSource File Content";
         String actualContent = targetFile.readToString();
         assertEquals(expectedContent, actualContent);

--- a/src/test/java/sp/sd/fileoperations/FileJoinOperationTest.java
+++ b/src/test/java/sp/sd/fileoperations/FileJoinOperationTest.java
@@ -1,0 +1,89 @@
+package sp.sd.fileoperations;
+
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.WithoutJenkins;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class FileJoinOperationTest {
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    @Test
+    @WithoutJenkins
+    public void testDefaults() {
+        FileJoinOperation fjo = new FileJoinOperation("source.txt", "target.txt");
+        assertEquals("source.txt", fjo.getSourceFile());
+        assertEquals("target.txt", fjo.getTargetFile());
+    }
+
+    @Test
+    public void testRunFileJoinOperation() throws Exception {
+        FreeStyleProject project = jenkins.createFreeStyleProject("fileJoinTest");
+
+        // Setup source file content
+        FilePath sourceFile = new FilePath(jenkins.jenkins.getWorkspaceFor(project), "source.txt");
+        sourceFile.write("Source File Content", StandardCharsets.UTF_8.name());
+
+        // Setup target file content
+        FilePath targetFile = new FilePath(jenkins.jenkins.getWorkspaceFor(project), "target.txt");
+        targetFile.write("Target File Content", StandardCharsets.UTF_8.name());
+
+        // Add FileJoinOperation to project
+        FileJoinOperation fileJoinOp = new FileJoinOperation("source.txt", "target.txt");
+        project.getBuildersList().add(new FileOperationsBuilder(List.of(fileJoinOp)));
+
+        // Run the build
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        assertEquals(Result.SUCCESS, build.getResult());
+
+        // Verify file join
+        String expectedContent = "Target File Content\nSource File Content";
+        String actualContent = targetFile.readToString();
+        assertEquals(expectedContent, actualContent);
+    }
+
+    @Test
+    public void testRunFileJoinOperationWithTokens() throws Exception {
+        // Setup environment variables
+        EnvironmentVariablesNodeProperty prop = new EnvironmentVariablesNodeProperty();
+        EnvVars envVars = prop.getEnvVars();
+        envVars.put("SOURCE_FILE", "source.txt");
+        envVars.put("TARGET_FILE", "target.txt");
+        jenkins.jenkins.getGlobalNodeProperties().add(prop);
+
+        FreeStyleProject project = jenkins.createFreeStyleProject("fileJoinTestWithTokens");
+
+        // Setup source file content
+        FilePath sourceFile = new FilePath(jenkins.jenkins.getWorkspaceFor(project), "source.txt");
+        sourceFile.write("Source File Content", StandardCharsets.UTF_8.name());
+
+        // Setup target file content
+        FilePath targetFile = new FilePath(jenkins.jenkins.getWorkspaceFor(project), "target.txt");
+        targetFile.write("Target File Content", StandardCharsets.UTF_8.name());
+
+        // Add FileJoinOperation to project
+        FileJoinOperation fileJoinOp = new FileJoinOperation("$SOURCE_FILE", "$TARGET_FILE");
+        project.getBuildersList().add(new FileOperationsBuilder(List.of(fileJoinOp)));
+
+        // Run the build
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        assertEquals(Result.SUCCESS, build.getResult());
+
+        // Verify file join
+        String expectedContent = "Target File Content\nSource File Content";
+        String actualContent = targetFile.readToString();
+        assertEquals(expectedContent, actualContent);
+    }
+}

--- a/src/test/java/sp/sd/fileoperations/FileJoinOperationTest.java
+++ b/src/test/java/sp/sd/fileoperations/FileJoinOperationTest.java
@@ -44,7 +44,7 @@ public class FileJoinOperationTest {
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         assertEquals(Result.SUCCESS, build.getResult());
 
-        String expectedContent = "Target File Content\nSource File Content";
+        String expectedContent = "Target File Content" + System.lineSeparator() + "Source File Content";
         String actualContent = targetFile.readToString();
         assertEquals(expectedContent, actualContent);
     }
@@ -71,7 +71,7 @@ public class FileJoinOperationTest {
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         assertEquals(Result.SUCCESS, build.getResult());
 
-        String expectedContent = "Target File Content\nSource File Content";
+        String expectedContent = "Target File Content" + System.lineSeparator() + "Source File Content";
         String actualContent = targetFile.readToString();
         assertEquals(expectedContent, actualContent);
     }


### PR DESCRIPTION
# Add Tests for FileJoinOperation

## Description
This pull request introduces a set of additional tests for the FileJoinOperation class, significantly increasing test coverage and ensuring the reliability of the file joining functionality. Enhanced the coverage of the FileJoinOperation class from 22% to 88%. 

## Related Issues
#74 

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
