### PR TITLE
Add Tests for FolderDeleteOperation

### DIFF
--- a/src/test/java/sp/sd/fileoperations/FolderDeleteOperationTest.java
+++ b/src/test/java/sp/sd/fileoperations/FolderDeleteOperationTest.java
@@ -1,0 +1,75 @@
+package sp.sd.fileoperations;
+
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class FolderDeleteOperationTest {
+
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    @Test
+    public void testDefaults() {
+        String folderPath = "folderToDelete";
+        FolderDeleteOperation operation = new FolderDeleteOperation(folderPath);
+
+        assertEquals(folderPath, operation.getFolderPath());
+    }
+
+    @Test
+    public void testRunFolderDeleteOperation() throws Exception {
+        FreeStyleProject project = jenkins.createFreeStyleProject("folderDeleteTest");
+
+        FilePath workspace = jenkins.jenkins.getWorkspaceFor(project);
+        FilePath folderToDelete = new FilePath(workspace, "folderToDelete");
+
+        folderToDelete.mkdirs();
+        FilePath fileInFolder = new FilePath(folderToDelete, "file.txt");
+        fileInFolder.write("Sample content", "UTF-8");
+
+        FolderDeleteOperation operation = new FolderDeleteOperation("folderToDelete");
+        project.getBuildersList().add(new FileOperationsBuilder(List.of(operation)));
+
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        assertEquals(Result.SUCCESS, build.getResult());
+
+        assertFalse("The folder should have been deleted", folderToDelete.exists());
+    }
+
+    @Test
+    public void testRunFolderDeleteOperationWithTokens() throws Exception {
+        EnvironmentVariablesNodeProperty prop = new EnvironmentVariablesNodeProperty();
+        EnvVars envVars = prop.getEnvVars();
+        envVars.put("FOLDER_TO_DELETE", "folderToDelete");
+        jenkins.jenkins.getGlobalNodeProperties().add(prop);
+
+        FreeStyleProject project = jenkins.createFreeStyleProject("folderDeleteTestWithTokens");
+
+        FilePath workspace = jenkins.jenkins.getWorkspaceFor(project);
+        FilePath folderToDelete = new FilePath(workspace, "folderToDelete");
+
+        folderToDelete.mkdirs();
+        FilePath fileInFolder = new FilePath(folderToDelete, "file.txt");
+        fileInFolder.write("Sample content", "UTF-8");
+
+        FolderDeleteOperation operation = new FolderDeleteOperation("$FOLDER_TO_DELETE");
+        project.getBuildersList().add(new FileOperationsBuilder(List.of(operation)));
+
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        assertEquals(Result.SUCCESS, build.getResult());
+
+        assertFalse("The folder should have been deleted", folderToDelete.exists());
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
# Add Tests for FolderDeleteOperation
## Description
This pull request introduces a set of additional tests for the FolderDeleteOperation class, significantly increasing test coverage and ensuring the reliability of the file joining functionality. Enhanced the coverage of the FolderDeleteOperation class from 25% to 87%.
## Related Issues
#74
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
