### PR TITLE
Add Tests for FileRenameOperation

### DIFF
--- a/src/test/java/sp/sd/fileoperations/FileRenameOperationTest.java
+++ b/src/test/java/sp/sd/fileoperations/FileRenameOperationTest.java
@@ -1,0 +1,77 @@
+package sp.sd.fileoperations;
+
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class FileRenameOperationTest {
+
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    @Test
+    public void testDefaults() {
+        String source = "source.txt";
+        String destination = "destination.txt";
+        FileRenameOperation operation = new FileRenameOperation(source, destination);
+
+        assertEquals(source, operation.getSource());
+        assertEquals(destination, operation.getDestination());
+    }
+
+    @Test
+    public void testRunFileRenameOperation() throws Exception {
+        FreeStyleProject project = jenkins.createFreeStyleProject("fileRenameTest");
+
+        FilePath workspace = jenkins.jenkins.getWorkspaceFor(project);
+        FilePath sourceFile = new FilePath(workspace, "source.txt");
+        FilePath destinationFile = new FilePath(workspace, "destination.txt");
+
+        sourceFile.write("Sample content", "UTF-8");
+
+        FileRenameOperation operation = new FileRenameOperation("source.txt", "destination.txt");
+        project.getBuildersList().add(new FileOperationsBuilder(List.of(operation)));
+
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        assertEquals(Result.SUCCESS, build.getResult());
+
+        assertFalse("The source file should have been renamed", sourceFile.exists());
+        assertTrue("The destination file should exist", destinationFile.exists());
+    }
+
+    @Test
+    public void testRunFileRenameOperationWithTokens() throws Exception {
+        EnvironmentVariablesNodeProperty prop = new EnvironmentVariablesNodeProperty();
+        EnvVars envVars = prop.getEnvVars();
+        envVars.put("SOURCE_FILE", "source.txt");
+        envVars.put("DESTINATION_FILE", "destination.txt");
+        jenkins.jenkins.getGlobalNodeProperties().add(prop);
+
+        FreeStyleProject project = jenkins.createFreeStyleProject("fileRenameTestWithTokens");
+
+        FilePath workspace = jenkins.jenkins.getWorkspaceFor(project);
+        FilePath sourceFile = new FilePath(workspace, "source.txt");
+        FilePath destinationFile = new FilePath(workspace, "destination.txt");
+
+        sourceFile.write("Sample content", "UTF-8");
+
+        FileRenameOperation operation = new FileRenameOperation("$SOURCE_FILE", "$DESTINATION_FILE");
+        project.getBuildersList().add(new FileOperationsBuilder(List.of(operation)));
+
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        assertEquals(Result.SUCCESS, build.getResult());
+
+        assertFalse("The source file should have been renamed", sourceFile.exists());
+        assertTrue("The destination file should exist", destinationFile.exists());
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
# Add Tests for FileRenameOperation
## Description
This pull request introduces a set of additional tests for the FileRenameOperation class, significantly increasing test coverage and ensuring the reliability of the file joining functionality. Enhanced the coverage of the FileRenameOperation class from 22% to 88%.
## Related Issues
#74
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
