### PR TITLE
Fixing: Zipping of directories and files without Parent directory reference

### DIFF
--- a/src/main/java/sp/sd/fileoperations/FileZipOperation.java
+++ b/src/main/java/sp/sd/fileoperations/FileZipOperation.java
@@ -13,6 +13,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.File;
 import java.io.Serializable;
+import java.util.List;
 
 public class FileZipOperation extends FileOperation implements Serializable {
 
@@ -75,7 +76,10 @@ public class FileZipOperation extends FileOperation implements Serializable {
                 FilePath fpTL = new FilePath(fpWS, resolvedFolderPath);
                 listener.getLogger().println(
                     "Creating Zip file of " + fpTL.getRemote() + " in " + fpWSOutput);
-                fpTL.zip(new FilePath(fpWSOutput, fpTL.getName() + ".zip"));
+                List<FilePath> files = fpTL.list();
+                for (FilePath file : files) {
+                    file.zip(new FilePath(fpWSOutput, file.getName() + ".zip"));
+                }
                 result = true;
             } catch (RuntimeException e) {
                 listener.fatalError(e.getMessage());


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

Issue Link: https://github.com/jenkinsci/file-operations-plugin/issues/133

Description:
I had fixed the process of zipping directories and files inside a parent directory into a zip file, 
which when unzipped, contains only the files and directory contents inside the parent directory, leaving out the parent directory.

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
